### PR TITLE
Added json_response to return data for all calls.

### DIFF
--- a/Basecamp/Api/AbstractApi.php
+++ b/Basecamp/Api/AbstractApi.php
@@ -83,7 +83,10 @@ abstract class AbstractApi
         $bc->send($message, $response);
         $data = new \stdClass();
         
-        $data->json_response = json_decode($response->getContent());
+        if($response->getStatusCode() == 201)
+            $data->json_response = json_decode($response->getContent());
+        else
+            $data->json_response = array();
 
         switch ($response->getStatusCode()) {
             case 201:


### PR DESCRIPTION
When making a resource (list, project, todo, etc) you really want to be able to see what the resultant ID is in order to create sub-resources (comments, todos, etc). So throw the response data into the return variable.
