### PR TITLE
Added the ability to overlap an HTTP transport creation

### DIFF
--- a/Basecamp/Api/AbstractApi.php
+++ b/Basecamp/Api/AbstractApi.php
@@ -9,9 +9,6 @@ use Buzz\Message\Request;
  */
 abstract class AbstractApi
 {
-    const BASE_URL = 'https://basecamp.com/';
-    const API_VERSION = '/api/v1';
-
     protected $client = null;
     private $timeout = 10;
 

--- a/Basecamp/Api/AbstractApi.php
+++ b/Basecamp/Api/AbstractApi.php
@@ -11,6 +11,7 @@ abstract class AbstractApi
 {
     protected $client = null;
     private $timeout = 10;
+    protected $page_size = 50;
 
     public function __construct(Client $client)
     {
@@ -20,8 +21,21 @@ abstract class AbstractApi
     final protected function get($resource, array $params = [])
     {
         $resource = empty($params) ? $resource : ($resource . (false === strpos($resource, '?') ? '?' : '&') . http_build_query($params, '', '&'));
-
         $response = $this->client->request(Request::METHOD_GET, $resource, [], $this->timeout);
+
+        // Fetch next pages
+        $page = 2;
+        $response_count = count($response);
+        while ($response_count == $this->page_size) {
+          $next_params = empty($params) ? ['page' => $page] : array_merge($params, ['page' => $page]);
+          $next_resource = ($resource . (false === strpos($resource, '?') ? '?' : '&') . http_build_query($next_params, '', '&'));
+          $next_response = $this->client->request(Request::METHOD_GET, $next_resource, [], $this->timeout);
+          if (!empty($next_response)) {
+            $response = array_merge($response, $next_response);
+          }
+          $response_count = count($next_response);
+          $page++;
+        }
 
         return $response;
     }

--- a/Basecamp/Api/AbstractApi.php
+++ b/Basecamp/Api/AbstractApi.php
@@ -71,7 +71,7 @@ abstract class AbstractApi
 
         $response = new Response();
 
-        $bc = new Curl();
+        $bc = $this->client->createCurl();
         $bc->setTimeout($this->timeout);
 
         if (!empty($this->client->getAccountData()['login']) && !empty($this->client->getAccountData()['password'])) {

--- a/Basecamp/Api/AbstractApi.php
+++ b/Basecamp/Api/AbstractApi.php
@@ -2,9 +2,7 @@
 namespace Basecamp\Api;
 
 use Basecamp\Client;
-use Buzz\Client\Curl;
 use Buzz\Message\Request;
-use Buzz\Message\Response;
 
 /**
  * Class AbstractApi.

--- a/Basecamp/Api/AbstractApi.php
+++ b/Basecamp/Api/AbstractApi.php
@@ -26,106 +26,30 @@ abstract class AbstractApi
     {
         $resource = empty($params) ? $resource : ($resource . (false === strpos($resource, '?') ? '?' : '&') . http_build_query($params, '', '&'));
 
-        $response = $this->request(Request::METHOD_GET, $resource);
+        $response = $this->client->request(Request::METHOD_GET, $resource, [], $this->timeout);
 
         return $response;
     }
 
     final protected function post($resource, array $params)
     {
-        $response = $this->request(Request::METHOD_POST, $resource, $params);
+        $response = $this->client->request(Request::METHOD_POST, $resource, $params, $this->timeout);
 
         return $response;
     }
 
     final protected function put($resource, array $params)
     {
-        $response = $this->request(Request::METHOD_PUT, $resource, $params);
+        $response = $this->client->request(Request::METHOD_PUT, $resource, $params, $this->timeout);
 
         return $response;
     }
 
     final protected function delete($resource)
     {
-        $response = $this->request(Request::METHOD_DELETE, $resource);
+        $response = $this->client->request(Request::METHOD_DELETE, $resource, [], $this->timeout);
 
         return $response;
     }
 
-    private function request($method, $resource, $params = [])
-    {
-        $message = new Request($method, $resource, self::BASE_URL . $this->client->getAccountData()['accountId'] . self::API_VERSION);
-        $message->setHeaders([
-            'User-Agent: ' . $this->client->getAccountData()['appName'],
-            'Content-Type: application/json',
-        ]);
-
-        if (!empty($params)) {
-            // When attaching files set content as is
-            if (array_key_exists('binary', $params)) {
-                $message->setContent($params['binary']);
-            } else {
-                $message->setContent(json_encode($params));
-            }
-        }
-
-        $response = new Response();
-
-        $bc = $this->client->createCurl();
-        $bc->setTimeout($this->timeout);
-
-        if (!empty($this->client->getAccountData()['login']) && !empty($this->client->getAccountData()['password'])) {
-            $bc->setOption(CURLOPT_USERPWD, $this->client->getAccountData()['login'] . ':' . $this->client->getAccountData()['password']);
-        } elseif (!empty($this->client->getAccountData()['token'])) {
-            $message->addHeader('Authorization: Bearer ' . $this->client->getAccountData()['token']);
-        }
-
-        $bc->send($message, $response);
-        $data = new \stdClass();
-
-        switch ($response->getStatusCode()) {
-            case 201:
-                $data = json_decode($response->getContent());
-                $data->message = 'Created';
-                break;
-            case 204:
-                $data->message = 'Resource succesfully deleted';
-                break;
-            case 304:
-                $data->message = '304 Not Modified';
-                break;
-            case 400:
-                $data->message = '400 Bad Request';
-                break;
-            case 403:
-                $data->message = '403 Forbidden';
-                break;
-            case 404:
-                $data->message = '404 Not Found';
-                break;
-            case 415:
-                $data->message = '415 Unsupported Media Type';
-                break;
-            case 429:
-                $data->message = '429 Too Many Requests. ' . $response->getHeader('Retry-After');
-                break;
-            case 500:
-                $data->message = '500 Hmm, that isn’t right';
-                break;
-            case 502:
-                $data->message = '502 Bad Gateway';
-                break;
-            case 503:
-                $data->message = '503 Service Unavailable';
-                break;
-            case 504:
-                $data->message = '504 Gateway Timeout';
-                break;
-            default:
-                $data = json_decode($response->getContent());
-                break;
-        }
-
-        return $data;
-    }
 }

--- a/Basecamp/Api/CalendarsEvents.php
+++ b/Basecamp/Api/CalendarsEvents.php
@@ -15,9 +15,9 @@ class CalendarsEvents extends AbstractApi
      *
      * @return array
      */
-    public function projectEvents($projectId)
+    public function projectEvents($projectId, array $params = [])
     {
-        $data = $this->get('/projects/' . $projectId . '/calendar_events.json');
+        $data = $this->get('/projects/' . $projectId . '/calendar_events.json', $params);
 
         return $data;
     }

--- a/Basecamp/Api/Todos.php
+++ b/Basecamp/Api/Todos.php
@@ -17,9 +17,9 @@ class Todos extends AbstractApi
      *
      * @return object
      */
-    public function show($projectId, $todoId)
+    public function show($projectId, $todoId, array $params = [])
     {
-        $data = $this->get('/projects/' . $projectId . '/todos/' . $todoId . '.json');
+        $data = $this->get('/projects/' . $projectId . '/todos/' . $todoId . '.json', $params);
         
         return $data;
     }

--- a/Basecamp/Client.php
+++ b/Basecamp/Client.php
@@ -1,6 +1,7 @@
 <?php
 namespace Basecamp;
 use Buzz\Client\Curl;
+use Buzz\Message\Response;
 use Basecamp\Api\Accesses;
 use Basecamp\Api\Attachments;
 use Basecamp\Api\CalendarsEvents;

--- a/Basecamp/Client.php
+++ b/Basecamp/Client.php
@@ -233,7 +233,7 @@ class Client
      *
      * @return mixed[]
      */
-    protected function request($method, $resource, $params = [], $timeout = 10)
+    public function request($method, $resource, $params = [], $timeout = 10)
     {
         $message = new Request($method, $resource, self::BASE_URL . $this->getAccountData()['accountId'] . self::API_VERSION);
         $message->setHeaders([

--- a/Basecamp/Client.php
+++ b/Basecamp/Client.php
@@ -1,5 +1,6 @@
 <?php
 namespace Basecamp;
+use Buzz\Client\Curl;
 use Basecamp\Api\Accesses;
 use Basecamp\Api\Attachments;
 use Basecamp\Api\CalendarsEvents;
@@ -45,6 +46,15 @@ class Client
     public function __construct(array $accountData)
     {
         $this->accountData = $accountData;
+    }
+
+    /**
+     * Create Curl client object
+     *
+     * Override to use Buzz extensions, for example CachedCurl
+     */
+    public function createCurl() {
+        return new Curl();
     }
 
     /**

--- a/Basecamp/Client.php
+++ b/Basecamp/Client.php
@@ -49,6 +49,17 @@ class Client
     }
 
     /**
+     * Set access token
+     *
+     * @param $value
+     * @return $this
+     */
+    public function setToken($value) {
+        $this->accountData['token'] = $value;
+        return $this;
+    }
+
+    /**
      * Create Curl client object
      *
      * Override to use Buzz extensions, for example CachedCurl

--- a/Basecamp/Client.php
+++ b/Basecamp/Client.php
@@ -1,6 +1,7 @@
 <?php
 namespace Basecamp;
 use Buzz\Client\Curl;
+use Buzz\Message\Request;
 use Buzz\Message\Response;
 use Basecamp\Api\Accesses;
 use Basecamp\Api\Attachments;
@@ -23,6 +24,9 @@ use Basecamp\Api\Uploads;
  */
 class Client
 {
+    const BASE_URL = 'https://basecamp.com/';
+    const API_VERSION = '/api/v1';
+
     /**
      * Account data.
      *


### PR DESCRIPTION
Added the ability to control the creation of the HTTP-transport (Curl).

Overlapping createCurl() method in Basecamp\Client class, you can further customize the created Curl object, or create a successor from Curl class, for example to implement caching.