### PR TITLE
fix issue with empty session and provide access to storage->clear()

### DIFF
--- a/Basecamp/Client.php
+++ b/Basecamp/Client.php
@@ -240,6 +240,16 @@ class Client
     }
 
     /**
+     * clear the saved cache stored in session
+     * useful when a user wants to get a full list of entries regardless of what was previously requested
+     */
+    public function clearCache()
+    {
+        $storage = Storage::get();
+        $storage->clear();
+    }
+
+    /**
      * Make HTTP Request.
      *
      * @return mixed[]
@@ -247,19 +257,19 @@ class Client
     public function request($method, $resource, $params = [], $timeout = 10)
     {
         $headers = [
-            'User-Agent: '.$this->getAccountData()['appName'],
+            'User-Agent: ' . $this->getAccountData()['appName'],
             'Content-Type: application/json',
-            ];
+        ];
 
         $storage = Storage::get();
         $hash = $storage->createHash($method, $resource, $params);
         $etag = $storage->get($hash);
 
         if ($etag) {
-            $headers[] = 'If-None-Match: '.$etag;
+            $headers[] = 'If-None-Match: ' . $etag;
         }
 
-        $message = new Request($method, $resource, self::BASE_URL.$this->getAccountData()['accountId'].self::API_VERSION);
+        $message = new Request($method, $resource, self::BASE_URL . $this->getAccountData()['accountId'] . self::API_VERSION);
         $message->setHeaders($headers);
 
         if (!empty($params)) {
@@ -277,9 +287,9 @@ class Client
         $bc->setTimeout($timeout);
 
         if (!empty($this->getAccountData()['login']) && !empty($this->getAccountData()['password'])) {
-            $bc->setOption(CURLOPT_USERPWD, $this->getAccountData()['login'].':'.$this->getAccountData()['password']);
+            $bc->setOption(CURLOPT_USERPWD, $this->getAccountData()['login'] . ':' . $this->getAccountData()['password']);
         } elseif (!empty($this->getAccountData()['token'])) {
-            $message->addHeader('Authorization: Bearer '.$this->getAccountData()['token']);
+            $message->addHeader('Authorization: Bearer ' . $this->getAccountData()['token']);
         }
 
         $bc->send($message, $response);
@@ -312,10 +322,10 @@ class Client
                 $data->message = '415 Unsupported Media Type';
                 break;
             case 429:
-                $data->message = '429 Too Many Requests. '.$response->getHeader('Retry-After');
+                $data->message = '429 Too Many Requests. ' . $response->getHeader('Retry-After');
                 break;
             case 500:
-                $data->message = '500 Hmm, that isn’t right';
+                $data->message = '500 Hmm, that isnï¿½t right';
                 break;
             case 502:
                 $data->message = '502 Bad Gateway';

--- a/Basecamp/StorageSession.php
+++ b/Basecamp/StorageSession.php
@@ -16,6 +16,11 @@ class StorageSession
             session_id('AtHe3hAtuP');
             session_start();
         }
+
+        // seed session with basecamp key if it isn't present
+        if (!isset($_SESSION['basecamp'])) {
+            $this->clear();
+        }
     }
 
     /**
@@ -23,11 +28,15 @@ class StorageSession
      *
      * @param $hash
      *
-     * @return string
+     * @return mixed return ETag string, otherwise return false
      */
     public function get($hash)
     {
-        return $_SESSION['basecamp'][$hash];
+        if (isset($_SESSION['basecamp'][$hash])) {
+            return $_SESSION['basecamp'][$hash];
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
I noticed an issue where the $_SESSION['basecamp'] was not set, this PR corrects that.

It also provides a pass through function from the client to storage clear function.  This is helpful when developeing a new integration and the dev needs to pull full data from basecamp without dealing with cache'd results
